### PR TITLE
Update `vault-login` Buildkite plugin to `v0.1.3`

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -33,7 +33,7 @@ steps:
     env:
       BUILDKITE_CLEAN_CHECKOUT: true
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - GITHUB_TOKEN
@@ -80,7 +80,7 @@ steps:
     command:
       - goreleaser release
     plugins:
-      - grapl-security/vault-login#v0.1.2
+      - grapl-security/vault-login#v0.1.3
       - grapl-security/vault-env#v0.1.0:
           secrets:
             - GITHUB_TOKEN
@@ -148,7 +148,7 @@ steps:
       - label: ":python: Publish Python SDK"
         depends_on: build-python-sdk
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - PYPI_API_TOKEN
@@ -164,7 +164,7 @@ steps:
         command:
           - .buildkite/scripts/npm-upload
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - NPM_API_TOKEN

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -74,7 +74,7 @@ steps:
         command:
           - make {{matrix.language}}-sdk test-{{matrix.language}}
         plugins:
-          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-login#v0.1.3
           - grapl-security/vault-env#v0.1.0:
               secrets:
                 - PULUMI_ACCESS_TOKEN


### PR DESCRIPTION
Update grapl-security/vault-login Buildkite plugin version to v0.1.3

Picks up additional logging features, specifically https://github.com/grapl-security/vault-login-buildkite-plugin/pull/26

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖