### PR TITLE
Update upstream provider to v0.33.0

### DIFF
--- a/provider/cmd/pulumi-resource-hcp/schema.json
+++ b/provider/cmd/pulumi-resource-hcp/schema.json
@@ -1416,7 +1416,7 @@
                 },
                 "cloudProvider": {
                     "type": "string",
-                    "description": "The provider where the HVN is located. Only 'aws' is available at this time.\n"
+                    "description": "The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.\n"
                 },
                 "createdAt": {
                     "type": "string",
@@ -1466,7 +1466,7 @@
                 },
                 "cloudProvider": {
                     "type": "string",
-                    "description": "The provider where the HVN is located. Only 'aws' is available at this time.\n",
+                    "description": "The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.\n",
                     "willReplaceOnChanges": true
                 },
                 "hvnId": {
@@ -1495,7 +1495,7 @@
                     },
                     "cloudProvider": {
                         "type": "string",
-                        "description": "The provider where the HVN is located. Only 'aws' is available at this time.\n",
+                        "description": "The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.\n",
                         "willReplaceOnChanges": true
                     },
                     "createdAt": {
@@ -2790,6 +2790,9 @@
                     },
                     "region": {
                         "type": "string"
+                    },
+                    "revokeAt": {
+                        "type": "string"
                     }
                 },
                 "type": "object",
@@ -2806,6 +2809,7 @@
                     "packerRunUuid",
                     "projectId",
                     "region",
+                    "revokeAt",
                     "id"
                 ]
             }
@@ -2867,6 +2871,9 @@
                     "projectId": {
                         "type": "string",
                         "description": "The ID of the project this HCP Packer registry is located in.\n"
+                    },
+                    "revokeAt": {
+                        "type": "string"
                     }
                 },
                 "type": "object",
@@ -2878,6 +2885,7 @@
                     "incrementalVersion",
                     "organizationId",
                     "projectId",
+                    "revokeAt",
                     "id"
                 ]
             }
@@ -2931,6 +2939,9 @@
                     "projectId": {
                         "type": "string"
                     },
+                    "revokeAt": {
+                        "type": "string"
+                    },
                     "ulid": {
                         "type": "string"
                     },
@@ -2948,6 +2959,7 @@
                     "incrementalVersion",
                     "organizationId",
                     "projectId",
+                    "revokeAt",
                     "ulid",
                     "updatedAt",
                     "id"

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -781,8 +781,8 @@ github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmX
 github.com/hashicorp/terraform-plugin-sdk v1.7.0/go.mod h1:OjgQmey5VxnPej/buEhe+YqKm0KNvV3QqU4hkqHqPCY=
 github.com/hashicorp/terraform-plugin-test v1.2.0 h1:AWFdqyfnOj04sxTdaAF57QqvW7XXrT8PseUHkbKsE8I=
 github.com/hashicorp/terraform-plugin-test v1.2.0/go.mod h1:QIJHYz8j+xJtdtLrFTlzQVC0ocr3rf/OjIpgZLK56Hs=
-github.com/hashicorp/terraform-provider-hcp v0.32.0 h1:DzOARu4TVEMmN38eJm1G89Rn9eog6fd/WUMw1FOuFDw=
-github.com/hashicorp/terraform-provider-hcp v0.32.0/go.mod h1:5xVHgAoaF1ajK3KSJM0XWcYDeb//v7fab37nqfdxsxk=
+github.com/hashicorp/terraform-provider-hcp v0.33.0 h1:0OpskmBJzOa5FpV/3m3CCwDUa0Aa0/UJmBA3iQqvSWc=
+github.com/hashicorp/terraform-provider-hcp v0.33.0/go.mod h1:5xVHgAoaF1ajK3KSJM0XWcYDeb//v7fab37nqfdxsxk=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/hashicorp/terraform-provider-hcp v0.32.0
+	github.com/hashicorp/terraform-provider-hcp v0.33.0
 )
 
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220523144019-a9dc436975cc

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -373,8 +373,8 @@ github.com/hashicorp/terraform-plugin-go v0.9.0/go.mod h1:EawBkgjBWNf7jiKnVoyDyF
 github.com/hashicorp/terraform-plugin-log v0.3.0/go.mod h1:EjueSP/HjlyFAsDqt+okpCPjkT4NDynAe32AeDC4vps=
 github.com/hashicorp/terraform-plugin-log v0.4.0 h1:F3eVnm8r2EfQCe2k9blPIiF/r2TT01SHijXnS7bujvc=
 github.com/hashicorp/terraform-plugin-log v0.4.0/go.mod h1:9KclxdunFownr4pIm1jdmwKRmE4d6HVG2c9XDq47rpg=
-github.com/hashicorp/terraform-provider-hcp v0.32.0 h1:DzOARu4TVEMmN38eJm1G89Rn9eog6fd/WUMw1FOuFDw=
-github.com/hashicorp/terraform-provider-hcp v0.32.0/go.mod h1:5xVHgAoaF1ajK3KSJM0XWcYDeb//v7fab37nqfdxsxk=
+github.com/hashicorp/terraform-provider-hcp v0.33.0 h1:0OpskmBJzOa5FpV/3m3CCwDUa0Aa0/UJmBA3iQqvSWc=
+github.com/hashicorp/terraform-provider-hcp v0.33.0/go.mod h1:5xVHgAoaF1ajK3KSJM0XWcYDeb//v7fab37nqfdxsxk=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
 github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/sdk/go/hcp/getPackerImage.go
+++ b/sdk/go/hcp/getPackerImage.go
@@ -82,6 +82,7 @@ type GetPackerImageResult struct {
 	PackerRunUuid  string                 `pulumi:"packerRunUuid"`
 	ProjectId      string                 `pulumi:"projectId"`
 	Region         string                 `pulumi:"region"`
+	RevokeAt       string                 `pulumi:"revokeAt"`
 }
 
 func GetPackerImageOutput(ctx *pulumi.Context, args GetPackerImageOutputArgs, opts ...pulumi.InvokeOption) GetPackerImageResultOutput {
@@ -175,6 +176,10 @@ func (o GetPackerImageResultOutput) ProjectId() pulumi.StringOutput {
 
 func (o GetPackerImageResultOutput) Region() pulumi.StringOutput {
 	return o.ApplyT(func(v GetPackerImageResult) string { return v.Region }).(pulumi.StringOutput)
+}
+
+func (o GetPackerImageResultOutput) RevokeAt() pulumi.StringOutput {
+	return o.ApplyT(func(v GetPackerImageResult) string { return v.RevokeAt }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/go/hcp/getPackerImageIteration.go
+++ b/sdk/go/hcp/getPackerImageIteration.go
@@ -72,6 +72,7 @@ type GetPackerImageIterationResult struct {
 	OrganizationId string `pulumi:"organizationId"`
 	// The ID of the project this HCP Packer registry is located in.
 	ProjectId string `pulumi:"projectId"`
+	RevokeAt  string `pulumi:"revokeAt"`
 }
 
 func GetPackerImageIterationOutput(ctx *pulumi.Context, args GetPackerImageIterationOutputArgs, opts ...pulumi.InvokeOption) GetPackerImageIterationResultOutput {
@@ -152,6 +153,10 @@ func (o GetPackerImageIterationResultOutput) OrganizationId() pulumi.StringOutpu
 // The ID of the project this HCP Packer registry is located in.
 func (o GetPackerImageIterationResultOutput) ProjectId() pulumi.StringOutput {
 	return o.ApplyT(func(v GetPackerImageIterationResult) string { return v.ProjectId }).(pulumi.StringOutput)
+}
+
+func (o GetPackerImageIterationResultOutput) RevokeAt() pulumi.StringOutput {
+	return o.ApplyT(func(v GetPackerImageIterationResult) string { return v.RevokeAt }).(pulumi.StringOutput)
 }
 
 func init() {

--- a/sdk/go/hcp/getPackerIteration.go
+++ b/sdk/go/hcp/getPackerIteration.go
@@ -64,6 +64,7 @@ type GetPackerIterationResult struct {
 	IncrementalVersion int    `pulumi:"incrementalVersion"`
 	OrganizationId     string `pulumi:"organizationId"`
 	ProjectId          string `pulumi:"projectId"`
+	RevokeAt           string `pulumi:"revokeAt"`
 	Ulid               string `pulumi:"ulid"`
 	UpdatedAt          string `pulumi:"updatedAt"`
 }
@@ -141,6 +142,10 @@ func (o GetPackerIterationResultOutput) OrganizationId() pulumi.StringOutput {
 
 func (o GetPackerIterationResultOutput) ProjectId() pulumi.StringOutput {
 	return o.ApplyT(func(v GetPackerIterationResult) string { return v.ProjectId }).(pulumi.StringOutput)
+}
+
+func (o GetPackerIterationResultOutput) RevokeAt() pulumi.StringOutput {
+	return o.ApplyT(func(v GetPackerIterationResult) string { return v.RevokeAt }).(pulumi.StringOutput)
 }
 
 func (o GetPackerIterationResultOutput) Ulid() pulumi.StringOutput {

--- a/sdk/go/hcp/hvn.go
+++ b/sdk/go/hcp/hvn.go
@@ -63,7 +63,7 @@ type Hvn struct {
 
 	// The CIDR range of the HVN. If this is not provided, the service will provide a default value.
 	CidrBlock pulumi.StringOutput `pulumi:"cidrBlock"`
-	// The provider where the HVN is located. Only 'aws' is available at this time.
+	// The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 	CloudProvider pulumi.StringOutput `pulumi:"cloudProvider"`
 	// The time that the HVN was created.
 	CreatedAt pulumi.StringOutput `pulumi:"createdAt"`
@@ -122,7 +122,7 @@ func GetHvn(ctx *pulumi.Context,
 type hvnState struct {
 	// The CIDR range of the HVN. If this is not provided, the service will provide a default value.
 	CidrBlock *string `pulumi:"cidrBlock"`
-	// The provider where the HVN is located. Only 'aws' is available at this time.
+	// The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 	CloudProvider *string `pulumi:"cloudProvider"`
 	// The time that the HVN was created.
 	CreatedAt *string `pulumi:"createdAt"`
@@ -143,7 +143,7 @@ type hvnState struct {
 type HvnState struct {
 	// The CIDR range of the HVN. If this is not provided, the service will provide a default value.
 	CidrBlock pulumi.StringPtrInput
-	// The provider where the HVN is located. Only 'aws' is available at this time.
+	// The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 	CloudProvider pulumi.StringPtrInput
 	// The time that the HVN was created.
 	CreatedAt pulumi.StringPtrInput
@@ -168,7 +168,7 @@ func (HvnState) ElementType() reflect.Type {
 type hvnArgs struct {
 	// The CIDR range of the HVN. If this is not provided, the service will provide a default value.
 	CidrBlock *string `pulumi:"cidrBlock"`
-	// The provider where the HVN is located. Only 'aws' is available at this time.
+	// The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 	CloudProvider string `pulumi:"cloudProvider"`
 	// The ID of the HashiCorp Virtual Network (HVN).
 	HvnId string `pulumi:"hvnId"`
@@ -180,7 +180,7 @@ type hvnArgs struct {
 type HvnArgs struct {
 	// The CIDR range of the HVN. If this is not provided, the service will provide a default value.
 	CidrBlock pulumi.StringPtrInput
-	// The provider where the HVN is located. Only 'aws' is available at this time.
+	// The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 	CloudProvider pulumi.StringInput
 	// The ID of the HashiCorp Virtual Network (HVN).
 	HvnId pulumi.StringInput
@@ -280,7 +280,7 @@ func (o HvnOutput) CidrBlock() pulumi.StringOutput {
 	return o.ApplyT(func(v *Hvn) pulumi.StringOutput { return v.CidrBlock }).(pulumi.StringOutput)
 }
 
-// The provider where the HVN is located. Only 'aws' is available at this time.
+// The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
 func (o HvnOutput) CloudProvider() pulumi.StringOutput {
 	return o.ApplyT(func(v *Hvn) pulumi.StringOutput { return v.CloudProvider }).(pulumi.StringOutput)
 }

--- a/sdk/nodejs/getPackerImage.ts
+++ b/sdk/nodejs/getPackerImage.ts
@@ -77,6 +77,7 @@ export interface GetPackerImageResult {
     readonly packerRunUuid: string;
     readonly projectId: string;
     readonly region: string;
+    readonly revokeAt: string;
 }
 
 export function getPackerImageOutput(args: GetPackerImageOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetPackerImageResult> {

--- a/sdk/nodejs/getPackerImageIteration.ts
+++ b/sdk/nodejs/getPackerImageIteration.ts
@@ -82,6 +82,7 @@ export interface GetPackerImageIterationResult {
      * The ID of the project this HCP Packer registry is located in.
      */
     readonly projectId: string;
+    readonly revokeAt: string;
 }
 
 export function getPackerImageIterationOutput(args: GetPackerImageIterationOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetPackerImageIterationResult> {

--- a/sdk/nodejs/getPackerIteration.ts
+++ b/sdk/nodejs/getPackerIteration.ts
@@ -55,6 +55,7 @@ export interface GetPackerIterationResult {
     readonly incrementalVersion: number;
     readonly organizationId: string;
     readonly projectId: string;
+    readonly revokeAt: string;
     readonly ulid: string;
     readonly updatedAt: string;
 }

--- a/sdk/nodejs/hvn.ts
+++ b/sdk/nodejs/hvn.ts
@@ -74,7 +74,7 @@ export class Hvn extends pulumi.CustomResource {
      */
     public readonly cidrBlock!: pulumi.Output<string>;
     /**
-     * The provider where the HVN is located. Only 'aws' is available at this time.
+     * The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
      */
     public readonly cloudProvider!: pulumi.Output<string>;
     /**
@@ -163,7 +163,7 @@ export interface HvnState {
      */
     cidrBlock?: pulumi.Input<string>;
     /**
-     * The provider where the HVN is located. Only 'aws' is available at this time.
+     * The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
      */
     cloudProvider?: pulumi.Input<string>;
     /**
@@ -205,7 +205,7 @@ export interface HvnArgs {
      */
     cidrBlock?: pulumi.Input<string>;
     /**
-     * The provider where the HVN is located. Only 'aws' is available at this time.
+     * The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
      */
     cloudProvider: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_hcp/get_packer_image.py
+++ b/sdk/python/pulumi_hcp/get_packer_image.py
@@ -20,7 +20,7 @@ class GetPackerImageResult:
     """
     A collection of values returned by getPackerImage.
     """
-    def __init__(__self__, bucket_name=None, build_id=None, cloud_image_id=None, cloud_provider=None, component_type=None, created_at=None, id=None, iteration_id=None, labels=None, organization_id=None, packer_run_uuid=None, project_id=None, region=None):
+    def __init__(__self__, bucket_name=None, build_id=None, cloud_image_id=None, cloud_provider=None, component_type=None, created_at=None, id=None, iteration_id=None, labels=None, organization_id=None, packer_run_uuid=None, project_id=None, region=None, revoke_at=None):
         if bucket_name and not isinstance(bucket_name, str):
             raise TypeError("Expected argument 'bucket_name' to be a str")
         pulumi.set(__self__, "bucket_name", bucket_name)
@@ -60,6 +60,9 @@ class GetPackerImageResult:
         if region and not isinstance(region, str):
             raise TypeError("Expected argument 'region' to be a str")
         pulumi.set(__self__, "region", region)
+        if revoke_at and not isinstance(revoke_at, str):
+            raise TypeError("Expected argument 'revoke_at' to be a str")
+        pulumi.set(__self__, "revoke_at", revoke_at)
 
     @property
     @pulumi.getter(name="bucketName")
@@ -129,6 +132,11 @@ class GetPackerImageResult:
     def region(self) -> str:
         return pulumi.get(self, "region")
 
+    @property
+    @pulumi.getter(name="revokeAt")
+    def revoke_at(self) -> str:
+        return pulumi.get(self, "revoke_at")
+
 
 class AwaitableGetPackerImageResult(GetPackerImageResult):
     # pylint: disable=using-constant-test
@@ -148,7 +156,8 @@ class AwaitableGetPackerImageResult(GetPackerImageResult):
             organization_id=self.organization_id,
             packer_run_uuid=self.packer_run_uuid,
             project_id=self.project_id,
-            region=self.region)
+            region=self.region,
+            revoke_at=self.revoke_at)
 
 
 def get_packer_image(bucket_name: Optional[str] = None,
@@ -202,7 +211,8 @@ def get_packer_image(bucket_name: Optional[str] = None,
         organization_id=__ret__.organization_id,
         packer_run_uuid=__ret__.packer_run_uuid,
         project_id=__ret__.project_id,
-        region=__ret__.region)
+        region=__ret__.region,
+        revoke_at=__ret__.revoke_at)
 
 
 @_utilities.lift_output_func(get_packer_image)

--- a/sdk/python/pulumi_hcp/get_packer_image_iteration.py
+++ b/sdk/python/pulumi_hcp/get_packer_image_iteration.py
@@ -21,7 +21,7 @@ class GetPackerImageIterationResult:
     """
     A collection of values returned by getPackerImageIteration.
     """
-    def __init__(__self__, bucket_name=None, builds=None, channel=None, created_at=None, id=None, incremental_version=None, organization_id=None, project_id=None):
+    def __init__(__self__, bucket_name=None, builds=None, channel=None, created_at=None, id=None, incremental_version=None, organization_id=None, project_id=None, revoke_at=None):
         if bucket_name and not isinstance(bucket_name, str):
             raise TypeError("Expected argument 'bucket_name' to be a str")
         pulumi.set(__self__, "bucket_name", bucket_name)
@@ -46,6 +46,9 @@ class GetPackerImageIterationResult:
         if project_id and not isinstance(project_id, str):
             raise TypeError("Expected argument 'project_id' to be a str")
         pulumi.set(__self__, "project_id", project_id)
+        if revoke_at and not isinstance(revoke_at, str):
+            raise TypeError("Expected argument 'revoke_at' to be a str")
+        pulumi.set(__self__, "revoke_at", revoke_at)
 
     @property
     @pulumi.getter(name="bucketName")
@@ -111,6 +114,11 @@ class GetPackerImageIterationResult:
         """
         return pulumi.get(self, "project_id")
 
+    @property
+    @pulumi.getter(name="revokeAt")
+    def revoke_at(self) -> str:
+        return pulumi.get(self, "revoke_at")
+
 
 class AwaitableGetPackerImageIterationResult(GetPackerImageIterationResult):
     # pylint: disable=using-constant-test
@@ -125,7 +133,8 @@ class AwaitableGetPackerImageIterationResult(GetPackerImageIterationResult):
             id=self.id,
             incremental_version=self.incremental_version,
             organization_id=self.organization_id,
-            project_id=self.project_id)
+            project_id=self.project_id,
+            revoke_at=self.revoke_at)
 
 
 def get_packer_image_iteration(bucket_name: Optional[str] = None,
@@ -167,7 +176,8 @@ def get_packer_image_iteration(bucket_name: Optional[str] = None,
         id=__ret__.id,
         incremental_version=__ret__.incremental_version,
         organization_id=__ret__.organization_id,
-        project_id=__ret__.project_id)
+        project_id=__ret__.project_id,
+        revoke_at=__ret__.revoke_at)
 
 
 @_utilities.lift_output_func(get_packer_image_iteration)

--- a/sdk/python/pulumi_hcp/get_packer_iteration.py
+++ b/sdk/python/pulumi_hcp/get_packer_iteration.py
@@ -20,7 +20,7 @@ class GetPackerIterationResult:
     """
     A collection of values returned by getPackerIteration.
     """
-    def __init__(__self__, author_id=None, bucket_name=None, channel=None, created_at=None, fingerprint=None, id=None, incremental_version=None, organization_id=None, project_id=None, ulid=None, updated_at=None):
+    def __init__(__self__, author_id=None, bucket_name=None, channel=None, created_at=None, fingerprint=None, id=None, incremental_version=None, organization_id=None, project_id=None, revoke_at=None, ulid=None, updated_at=None):
         if author_id and not isinstance(author_id, str):
             raise TypeError("Expected argument 'author_id' to be a str")
         pulumi.set(__self__, "author_id", author_id)
@@ -48,6 +48,9 @@ class GetPackerIterationResult:
         if project_id and not isinstance(project_id, str):
             raise TypeError("Expected argument 'project_id' to be a str")
         pulumi.set(__self__, "project_id", project_id)
+        if revoke_at and not isinstance(revoke_at, str):
+            raise TypeError("Expected argument 'revoke_at' to be a str")
+        pulumi.set(__self__, "revoke_at", revoke_at)
         if ulid and not isinstance(ulid, str):
             raise TypeError("Expected argument 'ulid' to be a str")
         pulumi.set(__self__, "ulid", ulid)
@@ -104,6 +107,11 @@ class GetPackerIterationResult:
         return pulumi.get(self, "project_id")
 
     @property
+    @pulumi.getter(name="revokeAt")
+    def revoke_at(self) -> str:
+        return pulumi.get(self, "revoke_at")
+
+    @property
     @pulumi.getter
     def ulid(self) -> str:
         return pulumi.get(self, "ulid")
@@ -129,6 +137,7 @@ class AwaitableGetPackerIterationResult(GetPackerIterationResult):
             incremental_version=self.incremental_version,
             organization_id=self.organization_id,
             project_id=self.project_id,
+            revoke_at=self.revoke_at,
             ulid=self.ulid,
             updated_at=self.updated_at)
 
@@ -170,6 +179,7 @@ def get_packer_iteration(bucket_name: Optional[str] = None,
         incremental_version=__ret__.incremental_version,
         organization_id=__ret__.organization_id,
         project_id=__ret__.project_id,
+        revoke_at=__ret__.revoke_at,
         ulid=__ret__.ulid,
         updated_at=__ret__.updated_at)
 

--- a/sdk/python/pulumi_hcp/hvn.py
+++ b/sdk/python/pulumi_hcp/hvn.py
@@ -19,7 +19,7 @@ class HvnArgs:
                  cidr_block: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Hvn resource.
-        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. Only 'aws' is available at this time.
+        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         :param pulumi.Input[str] hvn_id: The ID of the HashiCorp Virtual Network (HVN).
         :param pulumi.Input[str] region: The region where the HVN is located.
         :param pulumi.Input[str] cidr_block: The CIDR range of the HVN. If this is not provided, the service will provide a default value.
@@ -34,7 +34,7 @@ class HvnArgs:
     @pulumi.getter(name="cloudProvider")
     def cloud_provider(self) -> pulumi.Input[str]:
         """
-        The provider where the HVN is located. Only 'aws' is available at this time.
+        The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         """
         return pulumi.get(self, "cloud_provider")
 
@@ -94,7 +94,7 @@ class _HvnState:
         """
         Input properties used for looking up and filtering Hvn resources.
         :param pulumi.Input[str] cidr_block: The CIDR range of the HVN. If this is not provided, the service will provide a default value.
-        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. Only 'aws' is available at this time.
+        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         :param pulumi.Input[str] created_at: The time that the HVN was created.
         :param pulumi.Input[str] hvn_id: The ID of the HashiCorp Virtual Network (HVN).
         :param pulumi.Input[str] organization_id: The ID of the HCP organization where the HVN is located.
@@ -138,7 +138,7 @@ class _HvnState:
     @pulumi.getter(name="cloudProvider")
     def cloud_provider(self) -> Optional[pulumi.Input[str]]:
         """
-        The provider where the HVN is located. Only 'aws' is available at this time.
+        The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         """
         return pulumi.get(self, "cloud_provider")
 
@@ -280,7 +280,7 @@ class Hvn(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] cidr_block: The CIDR range of the HVN. If this is not provided, the service will provide a default value.
-        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. Only 'aws' is available at this time.
+        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         :param pulumi.Input[str] hvn_id: The ID of the HashiCorp Virtual Network (HVN).
         :param pulumi.Input[str] region: The region where the HVN is located.
         """
@@ -401,7 +401,7 @@ class Hvn(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] cidr_block: The CIDR range of the HVN. If this is not provided, the service will provide a default value.
-        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. Only 'aws' is available at this time.
+        :param pulumi.Input[str] cloud_provider: The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         :param pulumi.Input[str] created_at: The time that the HVN was created.
         :param pulumi.Input[str] hvn_id: The ID of the HashiCorp Virtual Network (HVN).
         :param pulumi.Input[str] organization_id: The ID of the HCP organization where the HVN is located.
@@ -437,7 +437,7 @@ class Hvn(pulumi.CustomResource):
     @pulumi.getter(name="cloudProvider")
     def cloud_provider(self) -> pulumi.Output[str]:
         """
-        The provider where the HVN is located. Only 'aws' is available at this time.
+        The provider where the HVN is located. The provider 'aws' is generally available and 'azure' is in public beta.
         """
         return pulumi.get(self, "cloud_provider")
 


### PR DESCRIPTION
See release notes at https://github.com/hashicorp/terraform-provider-hcp/releases/tag/v0.33.0

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
