### PR TITLE
Mount buildkite agent when validating the SDK

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -117,6 +117,7 @@ steps:
               download: sdk/python/bin/dist/*
           - docker#v5.3.0:
               image: "${BUILD_ENVIRONMENT_IMAGE}"
+              mount-buildkite-agent: true
 
       - label: ":nodejs: SDK Installation Validation"
         command:
@@ -126,6 +127,7 @@ steps:
               download: sdk/nodejs/bin/dist/*
           - docker#v5.3.0:
               image: "${BUILD_ENVIRONMENT_IMAGE}"
+              mount-buildkite-agent: true
 
       - label: ":go: SDK Installation Validation"
         command:
@@ -133,6 +135,7 @@ steps:
         plugins:
           - docker#v5.3.0:
               image: "${BUILD_ENVIRONMENT_IMAGE}"
+              mount-buildkite-agent: true
 
   - wait
 


### PR DESCRIPTION
We haven't done a release since we updated the Docker plugin, so this
snuck past us.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
